### PR TITLE
Update dockerfile to SDK 1.1.1

### DIFF
--- a/API/Dockerfile
+++ b/API/Dockerfile
@@ -1,6 +1,6 @@
 # Describes how to build a Docker image. Each instruction creates a new layer in the image. 
 
-FROM microsoft/dotnet:1.1.0-sdk-projectjson
+FROM microsoft/dotnet:1.1.1-sdk
 # This is good for deployed apps as it will be minimal, and no SDK 
 #FROM microsoft/dotnet:1.0.1-core 
 


### PR DESCRIPTION
Resolves #7.

(I think.)

As part of our previous setup, I believe we used project.json.

When I attempted to run `docker-compose up` from the root directory, I saw the error described in #7.

I realized that there had been previous updates that moved the project to the VS2017 / .csproj format (now the required format) and so I decided to update to `microsoft/dotnet:1.1.1-sdk`.

After doing this, it fixed my local docker behavior, as .NET was expecting the new .csproj format and was thus finding the project and able to restore it.